### PR TITLE
Pull Docker images though the Nectar container registry cache

### DIFF
--- a/au.org.nectar.GlamWorkbench/Resources/scripts/setup.sh
+++ b/au.org.nectar.GlamWorkbench/Resources/scripts/setup.sh
@@ -61,4 +61,4 @@ chown "${USERNAME}:${USERNAME}" ${WORKDIR}
 
 echo "Downloading and Installing ${WORKBENCH}"
 # Spin up the container
-docker run -d --rm -p 8888:8888 --name "$WORKBENCH" -v "$WORKDIR:/home/jovyan/work" "quay.io/glamworkbench/$WORKBENCH" repo2docker-entrypoint jupyter lab --ip 0.0.0.0 --ServerApp.token="$PASSWORD" --LabApp.default_url='/lab/tree/index.ipynb'
+docker run -d --rm -p 8888:8888 --name "$WORKBENCH" -v "$WORKDIR:/home/jovyan/work" "registry.rc.nectar.org.au/quay.io/glamworkbench/$WORKBENCH" repo2docker-entrypoint jupyter lab --ip 0.0.0.0 --ServerApp.token="$PASSWORD" --LabApp.default_url='/lab/tree/index.ipynb'


### PR DESCRIPTION
At the ARCOS symposium yesterday it was said that the registry cache is ready to use. I've tried pulling one of the GLAM Workbench images from quay.io and it seemed to work ok. Thought I might as well put the change in, and you can deploy as you see fit!